### PR TITLE
JNG-3844 Fixing optional Enum handling

### DIFF
--- a/src/main/java/hu/blackbelt/structured/map/proxy/MapProxy.java
+++ b/src/main/java/hu/blackbelt/structured/map/proxy/MapProxy.java
@@ -196,6 +196,8 @@ public final class MapProxy implements InvocationHandler {
                         } else {
                             throw new IllegalArgumentException(String.format("The attribute %s in %s is Optional. The Optional's generic type have to be interface.", attrName, sourceClass.getName()));
                         }
+                    } else if (optionalType.isEnum()) {
+                        internal.put(attrName, createEnumValue(value, optionalType));
                     } else if (optionalType.isAssignableFrom(value.getClass())) {
                         internal.put(attrName, value);
                     }

--- a/src/test/java/hu/blackbelt/structured/map/proxy/MapProxyTest.java
+++ b/src/test/java/hu/blackbelt/structured/map/proxy/MapProxyTest.java
@@ -93,6 +93,7 @@ public class MapProxyTest {
                 .get(((MapHolder) userDetail4).toMap())).get("id"));
 
         assertThat(user.getCountry().getName(), is("Austria"));
+
     }
 
     @Test
@@ -114,7 +115,13 @@ public class MapProxyTest {
         user.setMapWithoutType(ImmutableMap.of("k1", "v1"));
         user.setMapWithValueType(ImmutableMap.of("k1", userDetail3));
         user.setMapWithValueTypeAndKeyType(ImmutableMap.of(userDetail4, userDetail5));
+        user.setBirthCountry(Country.AT);
+
         performStructuralTestCases();
+
+        assertEquals(Optional.of(Country.AT), user.getBirthCountry());
+        assertEquals(Country.AT.toString(), getMapValue(user, "birthCountry", Country.class));
+
     }
 
     @Test
@@ -126,6 +133,7 @@ public class MapProxyTest {
         prepared.put("email", Optional.of("test@test.com"));
         prepared.put("loginName", Optional.of("teszt"));
         prepared.put("lastLoginTime", Optional.of(time));
+        prepared.put("birthCountry", Optional.of(Country.AT.getOrdinal()));
 
         user = MapProxy.builder(User.class).
                 withMap(prepared)
@@ -143,6 +151,10 @@ public class MapProxyTest {
 
         assertThat(map.get("firstName"), is(nullValue()));
         assertThat(user.getFirstName(), is(Optional.empty()));
+
+        assertThat(map.get("birthCountry"), is(Country.AT.getOrdinal()));
+        assertThat(user.getBirthCountry(), is(Optional.of(Country.AT)));
+
     }
 
     @Test
@@ -173,12 +185,18 @@ public class MapProxyTest {
         prepared.put("simpleUserDetail", null);
         prepared.put("sms", null);
         prepared.put("country", 3);
+        prepared.put("birthCountry", Country.AT.getOrdinal());
         user = MapProxy.builder(User.class).
                 withMap(prepared)
                 .withImmutable(true)
                 .withIdentifierField("id")
                 .withEnumMappingMethod("getOrdinal").newInstance();
+
         performStructuralTestCases();
+
+        assertEquals(Optional.of(Country.AT), user.getBirthCountry());
+        assertEquals(3, getMapValue(user, "birthCountry", Country.class));
+
     }
 
     @Test

--- a/src/test/java/hu/blackbelt/structured/map/proxy/entity/User.java
+++ b/src/test/java/hu/blackbelt/structured/map/proxy/entity/User.java
@@ -64,4 +64,9 @@ public interface User extends Entity {
 
     void setCountry(Country country);
 
+    Optional<Country> getBirthCountry();
+
+    void setBirthCountry(Country country);
+
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-3844" title="JNG-3844" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-3844</a>  MapProxy does not handle optional Enums when they have values
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
