### PR TITLE
JNG-5543 The Optional is null when the first letter of an attribute is uppercase

### DIFF
--- a/src/main/java/hu/blackbelt/structured/map/proxy/MapProxy.java
+++ b/src/main/java/hu/blackbelt/structured/map/proxy/MapProxy.java
@@ -196,7 +196,7 @@ public final class MapProxy implements InvocationHandler {
             }
 
             for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                String attrName = propertyDescriptor.getName();
+                String attrName = Character.toLowerCase(propertyDescriptor.getName().charAt(0)) + propertyDescriptor.getName().substring(1);
                 final Class propertyType = propertyDescriptor.getPropertyType();
                 Optional<ParameterizedType> parametrizedType = getGetterOrSetterParameterizedType(propertyDescriptor);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-5543" title="JNG-5543" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-5543</a>  If the first letter of an attribute name is uppercase in JSL the Optional is null in Java
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-5543 The Optional is null when the first letter of an attribute is uppercase